### PR TITLE
feat: add 2024 members info

### DIFF
--- a/src/assets/memberList.json
+++ b/src/assets/memberList.json
@@ -83,5 +83,33 @@
         "zt": "https://ztusers.github.io/",
         "uuuwind": "https://www.cnblogs.com/uuuwindwowo"
       }
+    },
+    "7": {
+      "level": "2024级",
+      "member": [
+        "Yime",
+        "Camille",
+        "Reinon",
+        "Duktig",
+        "Rxlls",
+        "Ord1nary",
+        "WEH",
+        "Liora",
+        "Riyi",
+        "Merlyn",
+        "COLLAPSING",
+        "Ziworld",
+        "Flaneur"
+      ],
+      "link": {
+        "Yime": "https://blog.r1ce.cn/",
+        "Camille": "https://camille-192.github.io/",
+        "Reinon": "https://blog.supid.cn/",
+        "Duktig": "https://douktig.github.io/",
+        "Rxlls": "https://blog.rxlls.cn/",
+        "Ord1nary": "https://ord1nary66.github.io/",
+        "COLLAPSING": "https://collasping.byethost22.com",
+        "Ziworld": "https://blog.ziworld.top"
+      }
     }
   }


### PR DESCRIPTION
本次 PR 主要更新内容如下：
- 新增 2024 级成员名单
- 新增 2024 级成员的个人博客链接
